### PR TITLE
Update POM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target/
+.classpath
+.project
+.settings/

--- a/pom.xml
+++ b/pom.xml
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.scijava</groupId>
         <artifactId>pom-scijava</artifactId>
         <version>23.1.1</version>
         <relativePath />
     </parent>
+
     <groupId>io.github.joheras</groupId>
     <artifactId>IJ-OpenCV</artifactId>
     <version>1.0.1-SNAPSHOT</version>
+
     <name>io.github.joheras:IJ-OpenCV</name>
     <description>A library that allows the connection of ImageJ and OpenCV.</description>
     <url>https://github.com/joheras/IJ-OpenCV</url>
@@ -24,34 +27,7 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
-    <mailingLists>
-        <mailingList>
-            <name>ImageJ Forum</name>
-            <archive>http://forum.imagej.net/</archive>
-        </mailingList>
-    </mailingLists>
-    <scm>
-        <connection>scm:git:git@github.com:joheras/IJ-OpenCV.git</connection>
-        <developerConnection>scm:git:git@github.com:joheras/IJ-OpenCV.git</developerConnection>
-        <url>git@github.com:joheras/IJ-OpenCV.git</url>
-    </scm>
-    <issueManagement>
-        <system>GitHub Issues</system>
-        <url>https://github.com/joheras/IJ-OpenCV/issues</url>
-    </issueManagement>
-    <ciManagement>
-        <system>None</system>
-    </ciManagement>
-    <properties>
-        <package-name>io.github.joheras.ijopencv</package-name>
-        <main-class>io.github.joheras.ijopencv</main-class>
-        <license.licenseName>bsd_2</license.licenseName>
-        <license.copyrightOwners>University of La Rioja</license.copyrightOwners>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <scijava.jvm.version>1.8</scijava.jvm.version>
-    </properties>
+
     <developers>
         <developer>
             <id>joheras</id>
@@ -75,12 +51,38 @@
             <name>Vico Pascual</name>
         </contributor>
     </contributors>
-    <repositories>
-        <repository>
-            <id>imagej.public</id>
-            <url>http://maven.imagej.net/content/groups/public</url>
-        </repository>
-    </repositories>
+
+    <mailingLists>
+        <mailingList>
+            <name>ImageJ Forum</name>
+            <archive>http://forum.imagej.net/</archive>
+        </mailingList>
+    </mailingLists>
+
+    <scm>
+        <connection>scm:git:git@github.com:joheras/IJ-OpenCV.git</connection>
+        <developerConnection>scm:git:git@github.com:joheras/IJ-OpenCV.git</developerConnection>
+        <url>git@github.com:joheras/IJ-OpenCV.git</url>
+    </scm>
+    <issueManagement>
+        <system>GitHub Issues</system>
+        <url>https://github.com/joheras/IJ-OpenCV/issues</url>
+    </issueManagement>
+    <ciManagement>
+        <system>None</system>
+    </ciManagement>
+
+    <properties>
+        <package-name>io.github.joheras.ijopencv</package-name>
+        <main-class>io.github.joheras.ijopencv</main-class>
+        <license.licenseName>bsd_2</license.licenseName>
+        <license.copyrightOwners>University of La Rioja</license.copyrightOwners>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <scijava.jvm.version>1.8</scijava.jvm.version>
+    </properties>
+
     <dependencies>   
         <!-- ImageJ dependencies -->
         <dependency>
@@ -115,4 +117,11 @@
         
 
     </dependencies>
+
+    <repositories>
+        <repository>
+            <id>imagej.public</id>
+            <url>http://maven.imagej.net/content/groups/public</url>
+        </repository>
+    </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,10 @@
         <contributor>
             <name>Vico Pascual</name>
         </contributor>
+        <contributor>
+            <name>Jan Eglinger</name>
+            <properties><id>imagejan</id></properties>
+        </contributor>
     </contributors>
 
     <mailingLists>

--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>org.scijava</groupId>
         <artifactId>pom-scijava</artifactId>
-        <version>12.0.0</version>
+        <version>23.1.1</version>
         <relativePath />
     </parent>
     <groupId>io.github.joheras</groupId>
     <artifactId>IJ-OpenCV</artifactId>
-    <version>1.0</version>
+    <version>1.0.1-SNAPSHOT</version>
     <name>io.github.joheras:IJ-OpenCV</name>
     <description>A library that allows the connection of ImageJ and OpenCV.</description>
     <url>https://github.com/joheras/IJ-OpenCV</url>
@@ -75,91 +75,6 @@
             <name>Vico Pascual</name>
         </contributor>
     </contributors>
-    <packaging>jar</packaging>
-    <distributionManagement>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.shared</groupId>
-                        <artifactId>maven-filtering</artifactId>
-                        <version>1.3</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-            
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.5</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            
- 
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                </configuration>
-            </plugin>
- 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
- 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
     <repositories>
         <repository>
             <id>imagej.public</id>
@@ -188,7 +103,6 @@
         <dependency>
             <groupId>org.scijava</groupId>
             <artifactId>scijava-common</artifactId>
-            <version>2.61.0</version>
             <type>jar</type>
         </dependency>
         <!-- JavaCV dependencies -->

--- a/src/main/java/ijopencv/ij/ImagePlusMatConverter.java
+++ b/src/main/java/ijopencv/ij/ImagePlusMatConverter.java
@@ -19,7 +19,8 @@ import org.scijava.log.LogService;
 import org.scijava.plugin.Plugin;
 
 /** 
- * @authors J. Heras and W. Burger
+ * @author J. Heras
+ * @author W. Burger
  */
 
 
@@ -108,7 +109,7 @@ public class ImagePlusMatConverter extends AbstractConverter< ImagePlus, Mat> {
      * Duplicates {@link ShortProcessor} to the corresponding OpenCV image of
      * type {@link Mat}.
      *
-     * @param bp The {@link ShortProcessor} to be converted
+     * @param sp The {@link ShortProcessor} to be converted
      * @return The OpenCV image (of type {@link Mat})
      */
     public static Mat toMat(ShortProcessor sp) {
@@ -122,7 +123,7 @@ public class ImagePlusMatConverter extends AbstractConverter< ImagePlus, Mat> {
      * Duplicates {@link FloatProcessor} to the corresponding OpenCV image of
      * type {@link Mat}.
      *
-     * @param bp The {@link FloatProcessor} to be converted
+     * @param cp The {@link FloatProcessor} to be converted
      * @return The OpenCV image (of type {@link Mat})
      */
     public static Mat toMat(FloatProcessor cp) {
@@ -136,7 +137,7 @@ public class ImagePlusMatConverter extends AbstractConverter< ImagePlus, Mat> {
      * Duplicates {@link ColorProcessor} to the corresponding OpenCV image of
      * type {@link Mat}.
      *
-     * @param bp The {@link ColorProcessor} to be converted
+     * @param cp The {@link ColorProcessor} to be converted
      * @return The OpenCV image (of type {@link Mat})
      */
     public static Mat toMat(ColorProcessor cp) {

--- a/src/main/java/ijopencv/opencv/MatImagePlusConverter.java
+++ b/src/main/java/ijopencv/opencv/MatImagePlusConverter.java
@@ -18,7 +18,8 @@ import org.scijava.log.LogService;
 import org.scijava.plugin.Plugin;
 
 /**
- * @authors J. Heras and W. Burger
+ * @author J. Heras
+ * @author W. Burger
  */
 @Plugin(type = Converter.class, priority = Priority.LOW_PRIORITY)
 public class MatImagePlusConverter extends AbstractConverter< Mat, ImagePlus> {


### PR DESCRIPTION
This PR updates `pom.xml` to inherit from the latest `pom-scijava` parent. This is a precondition to add continuous integration with Travis CI, and automated deployment to `maven.imagej.net` and Maven Central, to ensure reproducible builds.
