### PR TITLE
DistanceTransform Plugin

### DIFF
--- a/src/main/java/ijopencv/examples/Adaptive_ThresholdJ_.java
+++ b/src/main/java/ijopencv/examples/Adaptive_ThresholdJ_.java
@@ -27,7 +27,7 @@ import org.scijava.plugin.Plugin;
  *
  * @author jonathan
  */
-@Plugin(type = Command.class, headless = true, menuPath = "Plugins>IJ-OpenCV>Adaptive Threshold")
+@Plugin(type = Command.class, headless = true, menuPath = "Plugins>IJ-OpenCV-plugins>Adaptive Threshold")
 public class Adaptive_ThresholdJ_ implements Command {
 
     String method;

--- a/src/main/java/ijopencv/examples/DistanceTransform.java
+++ b/src/main/java/ijopencv/examples/DistanceTransform.java
@@ -1,0 +1,148 @@
+/*
+ * To the extent possible under law, the ImageJ developers have waived
+ * all copyright and related or neighboring rights to this tutorial code.
+ *
+ * See the CC0 1.0 Universal license for details:
+ *     http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+package ijopencv.examples;
+
+
+// import net.imglib2.type.numeric.RealType;
+
+import ij.gui.GenericDialog;
+
+import org.scijava.command.Command;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+import ij.IJ;
+import ij.ImagePlus;
+import ijopencv.ij.ImagePlusMatConverter;
+import ijopencv.opencv.MatImagePlusConverter;
+
+
+
+import static org.bytedeco.javacpp.opencv_imgproc.distanceTransform;
+import org.bytedeco.javacpp.opencv_imgproc;
+import org.bytedeco.javacpp.opencv_core;
+import org.bytedeco.javacpp.opencv_core.Mat;
+
+
+
+/**
+ * This example illustrates how to create an ImageJ {@link Command} plugin.
+ * <p>
+ * The code here is the DistanceTransform using ImageJ Ops.
+ * </p>
+ * <p>
+ * You should replace the parameter fields with your own inputs and outputs,
+ * and replace the {@link run} method implementation with your own logic.
+ * </p>
+ */
+@Plugin(type = Command.class, menuPath = "Plugins>IJ-OpenCV-plugins>DistanceTransform")
+public class DistanceTransform implements Command {
+    
+    String measure_method; // select the measurement method from openCV 
+    String speed; // select the correctness / speed for openCV
+    int threshold = 0; // select the threshold for 8bit gray, 0 means no threshold
+   
+    public DistanceTransform() {
+		// Auto-generated constructor stub
+	}
+    
+    
+    private boolean showDialog() {
+        GenericDialog gd = new GenericDialog("Distance Transform");
+        String[] items_measure = {"4Move", "8Move", "Euclidian"};
+        String[] items_speed = {"fast", "precise"};
+        gd.addChoice("Measure_Method", items_measure, items_measure[2]);
+        gd.addChoice("speed", items_speed, items_speed[1]);
+        gd.addNumericField("Threshold", threshold, 0);
+        
+        gd.showDialog();
+        if (gd.wasCanceled()) {
+            return false;
+        }
+
+        measure_method = gd.getNextChoice();
+        speed = gd.getNextChoice();
+        threshold = (int) gd.getNextNumber();
+        
+        return true;
+    }
+    
+	//
+    // Feel free to add more parameters here...
+    //
+	@Parameter
+    private ImagePlus imp;
+
+    @Override
+    public void run() {
+    	//Converter classes
+    	ImagePlusMatConverter ic = new ImagePlusMatConverter();
+		MatImagePlusConverter mip = new MatImagePlusConverter();
+        if (!showDialog()) {
+            return;
+        }
+        // transform strings from dialog into openCV int variable
+        int moveMethod;
+        if (measure_method == "4Move") {
+            moveMethod = opencv_imgproc.DIST_C;
+        }else if (measure_method == "8Move") {
+            moveMethod = opencv_imgproc.DIST_L1;
+        } else {
+            moveMethod = opencv_imgproc.DIST_L2;
+        }
+        
+        int moveDiagonal;
+        if (speed == "fast") {
+            moveDiagonal = 3;
+        } else {
+            moveDiagonal = 5;
+        }
+        
+		opencv_core.Mat src = ic.convert(imp, Mat.class); //imageplus into Mat
+		opencv_core.Mat res = new opencv_core.Mat(); // empty Mat
+		// threshold if needed (!=0)
+		if (threshold !=0) {
+			opencv_imgproc.threshold(src, src, threshold, 255, opencv_imgproc.THRESH_BINARY | opencv_imgproc.THRESH_OTSU);
+		}
+        //distanceTransform itself
+        distanceTransform(src, res, moveMethod, moveDiagonal);
+        
+        //back transform into imp2
+        ImagePlus imp2 = mip.convert(res, ImagePlus.class);
+        //get the initial title resultImage and add the transformation steps
+        imp2.setTitle( stripExtension(imp.getTitle())+"_"+measure_method+"_"+speed+"_EDT");
+        //imp2.setLut(Opener.openLut("fire.lut"));
+        IJ.run(imp2, "Fire",""); //LUT for 32Bit Float set from gray to fire
+        imp2.show();
+    }
+    // Modified from ImageJ code by Wayne Rasband and copied from LocalThickness
+ 	public String stripExtension(String name) {
+ 		if (name != null) {
+ 			final int dotIndex = name.lastIndexOf(".");
+ 			if (dotIndex >= 0) name = name.substring(0, dotIndex);
+ 		}
+ 		return name;
+ 	}
+   
+ 	public ImagePlus ij_opencv_disttransform(ImagePlus pic) {
+ 		ImagePlusMatConverter ic = new ImagePlusMatConverter();
+		MatImagePlusConverter mip = new MatImagePlusConverter();
+		opencv_core.Mat src = ic.convert(pic, Mat.class); //imageplus into Mat
+		opencv_core.Mat res = new opencv_core.Mat(); // empty Mat
+        //distanceTransform itself with default settings to fit results from LocalThick
+        distanceTransform(src, res, opencv_imgproc.DIST_L2, 5);
+        ImagePlus imp2 = mip.convert(res, ImagePlus.class);  //back transform into imp2
+        //get the initial title resultImage and add the transformation steps
+        imp2.setTitle(stripExtension(pic.getTitle())+"_EDT"); 
+        return imp2;
+ 	}
+ 
+}
+
+


### PR DESCRIPTION
Plugin IJ-openCV-DistanceTransform

The plugin uses the openCV function DistanceTransform and make it available under ImageJ

The plugin is mainly a replacement for the Analyze/Local Thickness/Geometry to Distance Map

The parameters utilized in the OpenCV function DistanceTransform can be set in the dialog box, the default values are Euclidean and 5 steps, this results in values closest to values of the Analyze/Local Thickness/Geometry to Distance Map and are also the  most correct ones:
The parameters DIST_L2 and 5 result in a maximal deviation to Analyze/Local Thickness/Geometry to Distance Map of 0.1 pixel. The absolute error is measured with a circle of 10 pixel perimeter thickness and results in a maximum error of 0.65 pixel. However here is the drawing procedure included in the error and there is the quantisation of 1 pixel.

**Speed**
The openCV DistanceTransform is sufficient fast to neglect the execution time during interactive image processing compared with Analyze/Local Thickness/Geometry:

```
Image size  execution time      execution time  improvement
pixel       Local Thickness(s)  opencv(s)
 2.3M       3                   0.6               5
 8.5M       38                  1.3              29
25.0M       86                  1.1              78
34.1M       293                 1.3             225
56.3M       289                 1.6             181
225M        fails               4.8             --


```
Larger pictures analyzed with Analyze/Local Thickness/Geometry give wrong results.
The exact execution time depends on the content of the image. Larger white areas usually result in more execution time.


**Dialogbox:**
The parameter described in openCV can be adjusted here. If the threshold is = 0: No threshold procedure is applied. If the value is !=0 the threshold is applied in between value and 255.

The title of the resulting image contains the source image name + the parameter from DistanceTransform used + _EDT

The plugin contains a callable function for other scripts, an example in Python is:
```
----------------------------------------------------------------------------------
from ij import IJ
from ijopencv.examples import DistanceTransform
path = "wherever_you_images_are"
imp2 = DistanceTransform().ij_opencv_disttransform(IJ.openImage(path))
imp2.show()
-----------------------------------------------------------------------------------

```
The procedure uses DIST_L2 and 5 and is silent


Limitations:
- The openCV only works with 2D images while the Analyze/Local Thickness/Geometry to Distance Map works also with 3D stacks. 
- The values of distance in the result image are in pixel, they are not
scaled.
- The procedure is 8bit image only, everything else results in an error

**ToDo**
Scaling
avoid the 8bit error message, transform the picture before?
