### PR TITLE
Improve Hough line example

### DIFF
--- a/src/main/java/ijopencv/examples/HoughLinesJ_.java
+++ b/src/main/java/ijopencv/examples/HoughLinesJ_.java
@@ -31,20 +31,20 @@ public class HoughLinesJ_  implements Command {
     @Parameter
     private ImagePlus imp;
     
-    @Parameter(label="Minimum line length (pixels)", min="1")
-    private int min_length;
+    @Parameter(label="Minimum line length (pixels)", min="1", stepSize="10")
+    private int min_length=10;
     
-    @Parameter(label="Step_line spacing iteration (pixels)", min="1")
-    private double step_line;
+    @Parameter(label="Step_line spacing iteration (pixels)", min="1", stepSize="10")
+    private double step_line=5;
     
-    @Parameter(label="Start_angle iteration (degrees)", min="0")
-    private double min_theta;
+    @Parameter(label="Start_angle iteration (degrees)", min="0", stepSize="10")
+    private double min_theta=0;
 
-    @Parameter(label="Stop_angle iteration (degrees)", min="0", max="180")
-    private double max_theta;
+    @Parameter(label="Stop_angle iteration (degrees)", min="0", max="180", stepSize="10")
+    private double max_theta=180;
     
-    @Parameter(label="Step_angle iteration (degrees)", min="1")
-    private double step_theta;
+    @Parameter(label="Step_angle iteration (degrees)", min="1", stepSize="5")
+    private double step_theta=5;
     
     @Override
     public void run() {

--- a/src/main/java/ijopencv/examples/HoughLinesJ_.java
+++ b/src/main/java/ijopencv/examples/HoughLinesJ_.java
@@ -31,11 +31,12 @@ public class HoughLinesJ_  implements Command {
 
     @Parameter
     private ImagePlus imp;
-    private ImageProcessor ImProc = imp.getProcessor();
     
     @Override
     public void run() {
-    	
+        
+    	ImageProcessor ImProc = imp.getProcessor();
+   
     	if ( !ImProc.isBinary() ) { //Hough line is defined for binary images
     		IJ.error("Image must be a 8-bit binary image (0-255 exclusively)");
     	}

--- a/src/main/java/ijopencv/examples/HoughLinesJ_.java
+++ b/src/main/java/ijopencv/examples/HoughLinesJ_.java
@@ -5,14 +5,13 @@ package ijopencv.examples;
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
+import ij.IJ;
 import ij.ImagePlus;
 import ij.gui.Line;
 import ij.gui.GenericDialog;
-import ij.plugin.filter.PlugInFilter;
 import ij.plugin.frame.RoiManager;
 import ij.process.ImageProcessor;
 import ijopencv.ij.ImagePlusMatConverter;
-import ijopencv.opencv.MatImagePlusConverter;
 import ijopencv.opencv.MatListLineConverter;
 import java.util.ArrayList;
 import org.bytedeco.javacpp.opencv_core;
@@ -32,43 +31,84 @@ public class HoughLinesJ_  implements Command {
 
     @Parameter
     private ImagePlus imp;
+    private ImageProcessor ImProc = imp.getProcessor();
     
     @Override
     public void run() {
-		
-		// GUI
-		GenericDialog gd = new GenericDialog("Hough Line");
-		gd.addNumericField("Minimum line length (pixels)", 10, 0);
-		gd.addNumericField("Step_line spacing iteration (pixels)", 10, 0);
-		gd.addNumericField("Start_angle iteration (degrees)", 0, 0);
-		gd.addNumericField("Stop_angle iteration (degrees)", 180, 0);
-		gd.addNumericField("Step_angle iteration (degrees)", 1, 0);
-		
-		
-		
-		
-        // Converters
-        ImagePlusMatConverter ic = new ImagePlusMatConverter();
-        MatImagePlusConverter mip = new MatImagePlusConverter();
+    	
+    	if ( !ImProc.isBinary() ) { //Hough line is defined for binary images
+    		IJ.error("Image must be a 8-bit binary image (0-255 exclusively)");
+    	}
+    	
+    	else {		
+	    	// GUI
+			GenericDialog gd = new GenericDialog("Hough Line");
+			gd.addNumericField("Minimum line length (pixels)", 10, 0);
+			gd.addNumericField("Step_line spacing iteration (pixels)", 10, 0);
+			gd.addNumericField("Start_angle iteration (degrees)", 0, 0);
+			gd.addNumericField("Stop_angle iteration (degrees)", 180, 0);
+			gd.addNumericField("Step_angle iteration (degrees)", 1, 0);
+			gd.showDialog();
+	    	
+			if ( gd.wasCanceled() ) {
+				return;
+			}
+			
+			else if ( gd.wasOKed() ) {
+				// Recover inputs
+				int min_length    = (int)gd.getNextNumber();
+				double step_line  = gd.getNextNumber();
+				double min_theta  = gd.getNextNumber();
+				double max_theta  = gd.getNextNumber();
+				double step_theta = gd.getNextNumber();
+				
+				// Do line detection
+				ArrayList<Line> linesIJ = HoughLines(imp, min_length, step_line, min_theta, max_theta, step_theta);
+				
+				// Add lines to RoiManager
+		        RoiManager rm = new RoiManager();
+		        rm.setVisible(true);
 
+		        for (int i = 0; i < linesIJ.size(); i++) {
+		            rm.add(imp, linesIJ.get(i), i);
+		        }
+			}
+    	}
+    }
+		
+	/**
+	 * Hough lines detection: Perform line detection on a binary image
+	 * @param imp        : 8-bit Binary ImagePlus 
+	 * @param min_length : Minimum number of points lying on a line to return it
+	 * @param step_line  : Step size (pixels) between parallel lines for iterative line search
+	 * @param min_theta  : Start looking for lines with orientation corresponding to this Rho angle (degrees)
+	 * @param max_theta  : Stop looking for lines with orientation corresponding to this Rho angle (degrees)
+	 * @param step_theta : Angle step size for line search (degrees) 
+	 * @return
+	 */
+	public ArrayList<Line> HoughLines(ImagePlus imp, int min_length, double step_line, double min_theta, double max_theta, double step_theta){
+        
+		// Initialise Imp>Mat Converters
+        ImagePlusMatConverter ic  = new ImagePlusMatConverter();
+        
+		// Convert input imp to Mat
         opencv_core.Mat m = ic.convert(imp, Mat.class);
-        MatListLineConverter lc = new MatListLineConverter();
-        Mat dst = new opencv_core.Mat();
-
-        opencv_imgproc.Canny(m, dst, 50, 200);
-
+        
+        // Convert from degrees to radians
+        min_theta  = Math.toRadians(min_theta);
+        max_theta  = Math.toRadians(max_theta);
+        step_theta = Math.toRadians(step_theta);
+        		
+		// Do Hough line detection
         Mat lines = new Mat();
-        opencv_imgproc.HoughLines(dst, lines, 1, opencv_core.CV_PI / 180, 100);
-
+        opencv_imgproc.HoughLines(m, lines, step_line, step_theta, min_length, 0, 0, min_theta, max_theta);
+		
+		// Convert lines Mat to ArrayList of ij line
+		MatListLineConverter lc = new MatListLineConverter();
         ArrayList<Line> linesIJ = new ArrayList<Line>();
         linesIJ = lc.convert(lines, linesIJ.getClass());
-        RoiManager rm = new RoiManager();
-        rm.setVisible(true);
-
-        for (int i = 0; i < linesIJ.size(); i++) {
-            rm.add(imp, linesIJ.get(i), i);
-        }
-
+        
+        return linesIJ;
     }
 
 }

--- a/src/main/java/ijopencv/examples/HoughLinesJ_.java
+++ b/src/main/java/ijopencv/examples/HoughLinesJ_.java
@@ -7,6 +7,7 @@ package ijopencv.examples;
  */
 import ij.ImagePlus;
 import ij.gui.Line;
+import ij.gui.GenericDialog;
 import ij.plugin.filter.PlugInFilter;
 import ij.plugin.frame.RoiManager;
 import ij.process.ImageProcessor;
@@ -34,6 +35,18 @@ public class HoughLinesJ_  implements Command {
     
     @Override
     public void run() {
+		
+		// GUI
+		GenericDialog gd = new GenericDialog("Hough Line");
+		gd.addNumericField("Minimum line length (pixels)", 10, 0);
+		gd.addNumericField("Step_line spacing iteration (pixels)", 10, 0);
+		gd.addNumericField("Start_angle iteration (degrees)", 0, 0);
+		gd.addNumericField("Stop_angle iteration (degrees)", 180, 0);
+		gd.addNumericField("Step_angle iteration (degrees)", 1, 0);
+		
+		
+		
+		
         // Converters
         ImagePlusMatConverter ic = new ImagePlusMatConverter();
         MatImagePlusConverter mip = new MatImagePlusConverter();

--- a/src/main/java/ijopencv/examples/HoughLinesJ_.java
+++ b/src/main/java/ijopencv/examples/HoughLinesJ_.java
@@ -8,7 +8,6 @@ package ijopencv.examples;
 import ij.IJ;
 import ij.ImagePlus;
 import ij.gui.Line;
-import ij.gui.GenericDialog;
 import ij.plugin.frame.RoiManager;
 import ij.process.ImageProcessor;
 import ijopencv.ij.ImagePlusMatConverter;
@@ -32,6 +31,21 @@ public class HoughLinesJ_  implements Command {
     @Parameter
     private ImagePlus imp;
     
+    @Parameter(label="Minimum line length (pixels)", min="1")
+    private int min_length;
+    
+    @Parameter(label="Step_line spacing iteration (pixels)", min="1")
+    private double step_line;
+    
+    @Parameter(label="Start_angle iteration (degrees)", min="0")
+    private double min_theta;
+
+    @Parameter(label="Stop_angle iteration (degrees)", min="0", max="180")
+    private double max_theta;
+    
+    @Parameter(label="Step_angle iteration (degrees)", min="1")
+    private double step_theta;
+    
     @Override
     public void run() {
         
@@ -41,41 +55,19 @@ public class HoughLinesJ_  implements Command {
     		IJ.error("Image must be a 8-bit binary image (0-255 exclusively)");
     	}
     	
-    	else {		
-	    	// GUI
-			GenericDialog gd = new GenericDialog("Hough Line");
-			gd.addNumericField("Minimum line length (pixels)", 10, 0);
-			gd.addNumericField("Step_line spacing iteration (pixels)", 10, 0);
-			gd.addNumericField("Start_angle iteration (degrees)", 0, 0);
-			gd.addNumericField("Stop_angle iteration (degrees)", 180, 0);
-			gd.addNumericField("Step_angle iteration (degrees)", 1, 0);
-			gd.showDialog();
-	    	
-			if ( gd.wasCanceled() ) {
-				return;
-			}
+    	else {	
+			// Do line detection
+			ArrayList<Line> linesIJ = HoughLines(imp, min_length, step_line, min_theta, max_theta, step_theta);
 			
-			else if ( gd.wasOKed() ) {
-				// Recover inputs
-				int min_length    = (int)gd.getNextNumber();
-				double step_line  = gd.getNextNumber();
-				double min_theta  = gd.getNextNumber();
-				double max_theta  = gd.getNextNumber();
-				double step_theta = gd.getNextNumber();
-				
-				// Do line detection
-				ArrayList<Line> linesIJ = HoughLines(imp, min_length, step_line, min_theta, max_theta, step_theta);
-				
-				// Add lines to RoiManager
-		        RoiManager rm = new RoiManager();
-		        rm.setVisible(true);
+			// Add lines to RoiManager
+	        RoiManager rm = new RoiManager();
+	        rm.setVisible(true);
 
-		        for (int i = 0; i < linesIJ.size(); i++) {
-		            rm.add(imp, linesIJ.get(i), i);
+	        for (int i = 0; i < linesIJ.size(); i++) {
+	            rm.add(imp, linesIJ.get(i), i);
 		        }
 			}
     	}
-    }
 		
 	/**
 	 * Hough lines detection: Perform line detection on a binary image

--- a/src/main/java/ijopencv/examples/HoughLinesJ_.java
+++ b/src/main/java/ijopencv/examples/HoughLinesJ_.java
@@ -26,9 +26,8 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Command.class, headless = true, menuPath = "Plugins>IJ-OpenCV-plugins>Hough lines")
 public class HoughLinesJ_  implements Command {
-
-
-    @Parameter
+			
+    @Parameter (validater="checkType")
     private ImagePlus imp;
     
     @Parameter(label="Minimum line length (pixels)", min="1", stepSize="10")
@@ -46,28 +45,33 @@ public class HoughLinesJ_  implements Command {
     @Parameter(label="Step_angle iteration (degrees)", min="1", stepSize="5")
     private double step_theta=5;
     
+    /**
+     * Function associated to Imp input: check image type
+     * Hough line is defined for binary images
+     * @param Imp : input ImagePlus
+     */
+    protected void checkType() {
+    	ImageProcessor ImProc = imp.getProcessor();
+    	if ( !ImProc.isBinary() ) {
+    		IJ.error("Image must be a 8-bit binary image (0-255 exclusively)");
+    		throw new IllegalArgumentException("Image must be a 8-bit binary image (0-255 exclusively)");
+    	}
+    }
+    
     @Override
     public void run() {
-        
-    	ImageProcessor ImProc = imp.getProcessor();
-   
-    	if ( !ImProc.isBinary() ) { //Hough line is defined for binary images
-    		IJ.error("Image must be a 8-bit binary image (0-255 exclusively)");
-    	}
-    	
-    	else {	
-			// Do line detection
-			ArrayList<Line> linesIJ = HoughLines(imp, min_length, step_line, min_theta, max_theta, step_theta);
-			
-			// Add lines to RoiManager
-	        RoiManager rm = new RoiManager();
-	        rm.setVisible(true);
+ 
+		// Do line detection
+		ArrayList<Line> linesIJ = HoughLines(imp, min_length, step_line, min_theta, max_theta, step_theta);
+		
+		// Add lines to RoiManager
+        RoiManager rm = new RoiManager();
+        rm.setVisible(true);
 
-	        for (int i = 0; i < linesIJ.size(); i++) {
-	            rm.add(imp, linesIJ.get(i), i);
-		        }
-			}
-    	}
+        for (int i = 0; i < linesIJ.size(); i++) {
+            rm.add(imp, linesIJ.get(i), i);
+	        }
+		}
 		
 	/**
 	 * Hough lines detection: Perform line detection on a binary image


### PR DESCRIPTION
Now shows a GUI (using ImageJ2 annotations) with parameters for Hough line detection (min line length..)
Allows only binary images as input (Hough is defined only for binary images) ie the edge detection and thresholding should be done before running the Hough example plugin