### PR TITLE
Update pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.scijava</groupId>
         <artifactId>pom-scijava</artifactId>
-        <version>26.0.0</version>
+        <version>29.0.0-beta-1</version>
         <relativePath />
     </parent>
 
@@ -117,19 +117,28 @@
             <groupId>net.imagej</groupId>
             <artifactId>imagej</artifactId>
         </dependency>
-        <!-- SciJava dependencies -->
+       
+       <!-- SciJava dependencies -->
         <dependency>
             <groupId>org.scijava</groupId>
             <artifactId>scijava-common</artifactId>
             <type>jar</type>
         </dependency>
-        <!-- JavaCV dependencies -->
+        
+        <!-- OpenCV platform (Windows, Linux, Android...) -->
         <dependency>
-            <groupId>org.bytedeco</groupId>
-            <artifactId>javacv-platform</artifactId>
-            <version>1.4.2</version>
+          <groupId>org.bytedeco.javacpp-presets</groupId>
+          <artifactId>opencv-platform</artifactId>
+          <version>3.4.2-1.4.2</version>
         </dependency>
-
+        
+        <!-- OpenCV (JavaCPP comes with it) -->
+        <dependency>
+          <groupId>org.bytedeco.javacpp-presets</groupId>
+          <artifactId>opencv</artifactId>
+          <version>3.4.2-1.4.2</version>
+        </dependency>
+        
     </dependencies>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.scijava</groupId>
         <artifactId>pom-scijava</artifactId>
-        <version>29.0.0-beta-1</version>
+        <version>29.2.1</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
- Use the latest scijava-pom version which rely on `scijava-maven-plugin 2.0.0` and so fix an issue of artifacts conflicts when using the `scijava.app.directory` property to compile ij-opencv with maven, see https://github.com/scijava/scijava-maven-plugin/issues/21#issuecomment-636183189 

- Also replace the "big" JavaCV dependency which was shipping a number of unused artifacts with only the `OpenCV` and `OpenCV-platform` artifacts, which will also pull javacpp if needed.